### PR TITLE
Only include coverage files when performing coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "pretest": "rimraf ./build",
     "test": "mocha-webpack \"src/**/*.ts\"",
-    "test.coverage": "nyc npm test",
+    "test.coverage": "NODE_ENV=test nyc npm test",
     "test.watch": "npm test -- --watch",
     "prepublishOnly": "npm run build",
     "lint": "tslint --project .",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -22,14 +22,16 @@ module.exports = {
                 test: /\.ts$/,
                 loaders: ["awesome-typescript-loader"],
             },
-            {
-                // For coverage testing
-                test: /\.(ts)/,
-                include: path.resolve("src"),
-                loader: "istanbul-instrumenter-loader",
-                enforce: "post",
-                exclude: [/node_modules/],
-            },
+            ...(process.env.NODE_ENV === "test"
+              ? [{
+                  test: /\.(ts)/,
+                  include: path.resolve("src"),
+                  loader: "istanbul-instrumenter-loader",
+                  enforce: "post",
+                  exclude: [/node_modules/],
+              }]
+              : []
+            )
         ],
     },
 


### PR DESCRIPTION
Coverage step in webpack was being performed on both build and test tasks, this was resulting in local paths in the bundle such as:
js
```
C:\\Users\\Dolan\\Documents\\docx\\src\\index.ts
```

Added NODE_ENV=coverage check in webpack config to prevent this during module build